### PR TITLE
Fix ES port and search syntax

### DIFF
--- a/docker/production.yml
+++ b/docker/production.yml
@@ -21,12 +21,12 @@ services:
   elasticsearch:
     image: huygensing/elasticsearch-tiny
     healthcheck:
-      test: "nc localhost 9300 < /dev/null"
+      test: "nc localhost 9200 < /dev/null"
       interval: 10s
       timeout: 3s
       retries: 5
     expose:
-      - "9300"
+      - "9200"
 
   topmod:
     image: huygensing/topmod

--- a/src/actions/search.ts
+++ b/src/actions/search.ts
@@ -1,8 +1,10 @@
 export const fullTextSearch = (query: string) => async (dispatch, getState) => {
 	const xhr = await fetch(`/api/documents/search`, {
 		body: JSON.stringify({
-			query_string: {
-				query: query
+			query: {
+				query_string: {
+					query: query
+				}
 			}
 		}),
 		headers: {


### PR DESCRIPTION
Janus now talks to ES on port 9200.

Search syntax now matches ES syntax. This is done so that faceted search (under construction) can use the same endpoint.